### PR TITLE
feat: json sanitize

### DIFF
--- a/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
+++ b/LogMonitor/LogMonitorTests/ConfigFileParserTests.cpp
@@ -307,8 +307,7 @@ namespace LogMonitorTests
                                 \"type\": \"File\",\
                                 \"directory\": \"%s\",\
                                 \"filter\": \"%s\",\
-                                \"includeSubdirectories\": %s,\
-                                \"includeFileNames\" : %s\
+                                \"includeSubdirectories\": %s\
                             }\
                         ]\
                     }\
@@ -318,7 +317,6 @@ namespace LogMonitorTests
             // First, try with this values.
             //
             bool includeSubdirectories = true;
-            bool includeFileNames = true;
 
             std::wstring directory = L"C:\\LogMonitor\\logs";
             std::wstring filter = L"*.*";
@@ -327,8 +325,7 @@ namespace LogMonitorTests
                     configFileStrFormat.c_str(),
                     Utility::ReplaceAll(directory, L"\\", L"\\\\").c_str(),
                     filter.c_str(),
-                    includeSubdirectories ? L"true" : L"false",
-                    includeFileNames ? L"true" : L"false"
+                    includeSubdirectories ? L"true" : L"false"
                 );
 
                 JsonFileParser jsonParser(configFileStr);
@@ -355,14 +352,12 @@ namespace LogMonitorTests
                 Assert::AreEqual(directory.c_str(), sourceFile->Directory.c_str());
                 Assert::AreEqual(filter.c_str(), sourceFile->Filter.c_str());
                 Assert::AreEqual(includeSubdirectories, sourceFile->IncludeSubdirectories);
-                Assert::AreEqual(includeFileNames, sourceFile->IncludeFileNames);
             }
 
             //
             // Try with different values
             //
             includeSubdirectories = false;
-            includeFileNames = false;
 
             directory = L"c:\\\\inetpub\\\\logs";
             filter = L"*.log";
@@ -372,8 +367,7 @@ namespace LogMonitorTests
                     configFileStrFormat.c_str(),
                     Utility::ReplaceAll(directory, L"\\", L"\\\\").c_str(),
                     filter.c_str(),
-                    includeSubdirectories ? L"true" : L"false",
-                    includeFileNames ? L"true" : L"false"
+                    includeSubdirectories ? L"true" : L"false"
                 );
 
                 JsonFileParser jsonParser(configFileStr);
@@ -400,7 +394,6 @@ namespace LogMonitorTests
                 Assert::AreEqual(directory.c_str(), sourceFile->Directory.c_str());
                 Assert::AreEqual(filter.c_str(), sourceFile->Filter.c_str());
                 Assert::AreEqual(includeSubdirectories, sourceFile->IncludeSubdirectories);
-                Assert::AreEqual(includeFileNames, sourceFile->IncludeFileNames);
             }
         }
 
@@ -454,7 +447,6 @@ namespace LogMonitorTests
                 Assert::AreEqual(directory.c_str(), sourceFile->Directory.c_str());
                 Assert::AreEqual(L"", sourceFile->Filter.c_str());
                 Assert::AreEqual(false, sourceFile->IncludeSubdirectories);
-                Assert::AreEqual(false, sourceFile->IncludeFileNames);
             }
         }
 

--- a/LogMonitor/LogMonitorTests/EtwMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/EtwMonitorTests.cpp
@@ -82,20 +82,36 @@ namespace LogMonitorTests
 
                 //
                 // The "Microsoft-Windows-User-Diagnostic" provider produces events
-                // like this:
+                // like this (without the space formatting / one-line):
                 //
-                //  <Source>EtwEvent</Source><Time>2019-11-04T18:04:33.000Z</Time>
-                //  <Provider idGuid="{305FC87B-002A-5E26-D297-60223012CA9C}"/>
-                //  <DecodingSource>DecodingSourceXMLFile</DecodingSource>
-                //  <Execution ProcessID="3968" ThreadID="2504" /><Level>Warning</Level>
-                //  <Keyword>0x0</Keyword><EventID Qualifiers="1">1</EventID>
-                //  <EventData><ErrorCode>0x3F0</ErrorCode></EventData>
+                /*
+                    {
+                        "Source": "ETW",
+                        "LogEntry" : {
+                            "Time": "2022-12-22T13:39:20.000Z",
+                            "ProviderName" : "Microsoft-Windows-User-Diagnostic",
+                            "ProviderId" : "{305FC87B-002A-5E26-D297-60223012CA9C}",
+                            "DecodingSource" : "DecodingSourceXMLFile",
+                            "Execution" : {
+                                "ProcessId": 35344,
+                                "ThreadId" : 36976
+                            },
+                            "Level" : "Warning",
+                            "Keyword" : "0x0",
+                            "EventId" : 1,
+                            "EventData" : {
+                                "ErrorCode": "0x102"
+                            }
+                        },
+                        "SchemaVersion": "1.0.0"
+                    }
+                */
                 //
 
                 //
                 // Verify time was printed.
                 //
-                std::wregex rgxTime(L"<Time>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z<\\/Time>");
+                std::wregex rgxTime(L"\"Time\":\"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z\",");
 
                 Assert::IsTrue(std::regex_search(output, rgxTime),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -103,7 +119,7 @@ namespace LogMonitorTests
                 //
                 // Verify provider GUID was printed.
                 //
-                std::wregex rgxProvider(L"<Provider[^>]*[\\da-fA-F]{8}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{12}");
+                std::wregex rgxProvider(L"\"ProviderId\":\".*[\\da-fA-F]{8}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{12}");
 
                 Assert::IsTrue(std::regex_search(output, rgxProvider),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -111,7 +127,7 @@ namespace LogMonitorTests
                 //
                 // Verify level was printed.
                 //
-                std::wregex rgxLevel(L"<Level>(None|Critical|Error|Warning|Information|Verbose)<\\/Level>");
+                std::wregex rgxLevel(L"\"Level\":\"(None|Critical|Error|Warning|Information|Verbose)\",");
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -119,7 +135,7 @@ namespace LogMonitorTests
                 //
                 // Verify keyword was printed.
                 //
-                std::wregex rgxKeyword(L"<Keyword>0x[\\da-fA-F]+<\\/Keyword>");
+                std::wregex rgxKeyword(L"\"Keyword\":\"0x[\\da-fA-F]+\",");
 
                 Assert::IsTrue(std::regex_search(output, rgxKeyword),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -127,7 +143,7 @@ namespace LogMonitorTests
                 //
                 // Verify event data was printed.
                 //
-                std::wregex rgxData(L"<EventData>.*<ErrorCode>0x[\\da-fA-F]+<\\/ErrorCode>.*<\\/EventData>");
+                std::wregex rgxData(L"\"EventData\":.*\"ErrorCode\":\"0x[\\da-fA-F]+\".*");
 
                 Assert::IsTrue(std::regex_search(output, rgxData),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());

--- a/LogMonitor/LogMonitorTests/EventMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/EventMonitorTests.cpp
@@ -122,7 +122,7 @@ namespace LogMonitorTests
                 std::wstring output;
                 int count = 0;
                 
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -136,12 +136,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                                Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -168,7 +168,7 @@ namespace LogMonitorTests
                 //
                 // Monitor should have ignored this event.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 Assert::IsFalse(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -195,7 +195,7 @@ namespace LogMonitorTests
                 //
                 // Monitor should have ignored this event.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 Assert::IsFalse(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -228,7 +228,7 @@ namespace LogMonitorTests
                 std::wstring output;
                 int count = 0;
                 
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -239,12 +239,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -270,7 +270,7 @@ namespace LogMonitorTests
                 // Test that the created event is printed. We could receive other events,
                 // so is better to loop until our message has arrived, using a regex.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -281,12 +281,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -312,7 +312,7 @@ namespace LogMonitorTests
                 // Test that the created event is printed. We could receive other events,
                 // so is better to loop until our message has arrived, using a regex.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", message.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", message.c_str()));
 
                 do
                 {
@@ -323,12 +323,12 @@ namespace LogMonitorTests
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxId(Utility::FormatString(L"<EventId>%d<\\/EventId>", eventId));
+                std::wregex rgxId(Utility::FormatString(L"\"EventId\": %d", eventId));
 
                 Assert::IsTrue(std::regex_search(output, rgxId),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
 
-                std::wregex rgxLevel(Utility::FormatString(L"<Level>%s<\\/Level>", c_LevelToString[(int)level]));
+                std::wregex rgxLevel(Utility::FormatString(L"\"Level\": \"%s\"", c_LevelToString[(int)level]));
 
                 Assert::IsTrue(std::regex_search(output, rgxLevel),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -368,7 +368,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && READ_OUTPUT_RETRIES > ++count);
 
-                std::wregex rgxMessage(Utility::FormatString(L"<Channel>Application<\\/Channel>"));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Channel\": \"Application\""));
 
                 Assert::IsTrue(std::regex_search(output, rgxMessage),
                     Utility::FormatString(L"Actual output: %s", output.c_str()).c_str());
@@ -398,7 +398,7 @@ namespace LogMonitorTests
                 Sleep(WAIT_TIME_EVENTMONITOR_AFTER_WRITE_LONG);
                 std::wstring output = RecoverOuput();
 
-                std::wregex rgxMessage(Utility::FormatString(L"<Channel>Application<\\/Channel>"));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Channel\": \"Application\""));
 
                 //
                 // We can not ensure that a System event isn't received right
@@ -448,7 +448,7 @@ namespace LogMonitorTests
                 // Test that the created event is printed. We could receive other events,
                 // so is better to loop until our message has arrived, using a regex.
                 //
-                std::wregex rgxMessage(Utility::FormatString(L"<Message>%s<\\/Message>", messageWithoutNewline.c_str()));
+                std::wregex rgxMessage(Utility::FormatString(L"\"Message\": \"%s\"", messageWithoutNewline.c_str()));
 
                 do
                 {

--- a/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
+++ b/LogMonitor/LogMonitorTests/LogFileMonitorTests.cpp
@@ -176,7 +176,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -224,7 +224,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -257,7 +257,7 @@ namespace LogMonitorTests
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
                 output = RecoverOuput();
-                Assert::IsTrue(output.find((TO_WSTR(content) + L"\n").c_str()) == 0);
+                Assert::IsTrue(output.find((TO_WSTR(content)).c_str()) != std::wstring::npos);
             }
         }
         
@@ -288,12 +288,11 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
-            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -396,7 +395,7 @@ namespace LogMonitorTests
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -451,7 +450,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((content + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(content) != std::wstring::npos);
             }
 
             //
@@ -486,7 +485,7 @@ namespace LogMonitorTests
                     output = RecoverOuput();
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
-                Assert::AreEqual((content + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(content) != std::wstring::npos);
             }
 
             //
@@ -514,7 +513,7 @@ namespace LogMonitorTests
 
                 MultiByteToWideChar(CP_UTF8, 0, (LPCCH)content.c_str(), (int)content.length(), (LPWSTR)(contentWide.c_str()), size_needed);
 
-                Assert::AreEqual((contentWide + L"\n").c_str(), output.c_str());
+                Assert::IsTrue(output.find(contentWide) != std::wstring::npos);
             }
 
             //
@@ -567,12 +566,11 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
-            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -673,12 +671,11 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
-            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -739,11 +736,6 @@ namespace LogMonitorTests
 
                 std::wstring filename = sourceFile.Directory + L"\\longline.log";
                 std::string content(20000, '#');
-                
-                //
-                // Add a new line to check that it doesn't break all.
-                //
-                content += '\n';
 
                 status = WriteToFile(filename, content.c_str(), content.length());
                 
@@ -798,12 +790,11 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
-            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -950,7 +941,7 @@ namespace LogMonitorTests
                 // It should the FULL content of the file, that's why we need
                 // to concatenate twice the content.
                 //
-                Assert::IsTrue(output.find((TO_WSTR(content) + TO_WSTR(content) + L"\n").c_str()) != std::wstring::npos);
+                Assert::IsTrue(output.find((TO_WSTR(content) + TO_WSTR(content)).c_str()) != std::wstring::npos);
             }
         }
 
@@ -989,12 +980,11 @@ namespace LogMonitorTests
             sourceFile.Directory = tempDirectory;
             sourceFile.Filter = L"*.log";
             sourceFile.IncludeSubdirectories = true;
-            sourceFile.IncludeFileNames = true;
 
             fflush(stdout);
             ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
 
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
+            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories);
             Sleep(WAIT_TIME_LOGFILEMONITOR_START);
 
             //
@@ -1065,124 +1055,6 @@ namespace LogMonitorTests
                 } while (output.empty() && retries < READ_OUTPUT_RETRIES);
 
                 Assert::IsTrue(output.find(TO_WSTR(content)) != std::wstring::npos);
-            }
-        }
-
-        //
-        // Check that if IncludeFileNames field is set to true,
-        // the LogFileMonitor prints the file name
-        //
-        TEST_METHOD(TestIncludeFileNames)
-        {
-            std::wstring output;
-
-            std::wstring tempDirectory = CreateTempDirectory();
-            Assert::IsFalse(tempDirectory.empty());
-
-            directoriesToDeleteAtCleanup.push_back(tempDirectory);
-
-            //
-            // Create subdirectory
-            //
-            std::wstring subDirectory = tempDirectory + L"\\sub";
-            long status = CreateDirectoryW(subDirectory.c_str(), NULL);
-            Assert::AreNotEqual(0L, status);
-
-            //
-            // Start the monitor
-            //
-            SourceFile sourceFile;
-            sourceFile.Directory = tempDirectory;
-            sourceFile.Filter = L"*.log";
-            sourceFile.IncludeSubdirectories = true;
-            sourceFile.IncludeFileNames = true;
-
-            fflush(stdout);
-            ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
-
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
-            Sleep(WAIT_TIME_LOGFILEMONITOR_START);
-
-            //
-            // Check if the short path could be doing something wrong.
-            //
-            {
-                fflush(stdout);
-                ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
-
-                std::string fileName = "includefilename.log";
-                std::wstring longFilename = sourceFile.Directory + L"\\" + TO_WSTR(fileName);
-                std::string content = "Testing!";
-
-                WriteToFile(longFilename, content.c_str(), content.length());
-
-                int retries = 0;
-                do {
-                    retries++;
-                    Sleep(WAIT_TIME_LOGFILEMONITOR_AFTER_WRITE_SHORT);
-                    output = RecoverOuput();
-                } while (output.empty() && retries < READ_OUTPUT_RETRIES);
-
-                Assert::IsTrue(output.find(TO_WSTR(fileName)) != std::wstring::npos);
-            }
-        }
-
-        //
-        // Check that if IncludeFileNames field is set to false,
-        // the LogFileMonitor does not print the file name
-        //
-        TEST_METHOD(TestDoNotIncludeFileNames)
-        {
-            std::wstring output;
-
-            std::wstring tempDirectory = CreateTempDirectory();
-            Assert::IsFalse(tempDirectory.empty());
-
-            directoriesToDeleteAtCleanup.push_back(tempDirectory);
-
-            //
-            // Create subdirectory
-            //
-            std::wstring subDirectory = tempDirectory + L"\\sub";
-            long status = CreateDirectoryW(subDirectory.c_str(), NULL);
-            Assert::AreNotEqual(0L, status);
-
-            //
-            // Start the monitor
-            //
-            SourceFile sourceFile;
-            sourceFile.Directory = tempDirectory;
-            sourceFile.Filter = L"*.log";
-            sourceFile.IncludeSubdirectories = true;
-            sourceFile.IncludeFileNames = false;
-
-            fflush(stdout);
-            ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
-
-            std::shared_ptr<LogFileMonitor> logfileMon = std::make_shared<LogFileMonitor>(sourceFile.Directory, sourceFile.Filter, sourceFile.IncludeSubdirectories, sourceFile.IncludeFileNames);
-            Sleep(WAIT_TIME_LOGFILEMONITOR_START);
-
-            //
-            // Check if the short path could be doing something wrong.
-            //
-            {
-                fflush(stdout);
-                ZeroMemory(bigOutBuf, sizeof(bigOutBuf));
-
-                std::string fileName = "donotIncludefilename.log";
-                std::wstring longFilename = sourceFile.Directory + L"\\" + TO_WSTR(fileName);
-                std::string content = "Testing!";
-
-                WriteToFile(longFilename, content.c_str(), content.length());
-
-                int retries = 0;
-                do {
-                    retries++;
-                    Sleep(WAIT_TIME_LOGFILEMONITOR_AFTER_WRITE_SHORT);
-                    output = RecoverOuput();
-                } while (output.empty() && retries < READ_OUTPUT_RETRIES);
-
-                Assert::IsFalse(output.find(TO_WSTR(fileName)) != std::wstring::npos);
             }
         }
     };

--- a/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
+++ b/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj
@@ -176,6 +176,7 @@
     </ClCompile>
     <ClCompile Include="ConfigFileParserTests.cpp" />
     <ClCompile Include="Utility.cpp" />
+    <ClCompile Include="UtilityTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj.filters
+++ b/LogMonitor/LogMonitorTests/LogMonitorTests.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="Utility.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UtilityTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/LogMonitor/LogMonitorTests/UtilityTests.cpp
+++ b/LogMonitor/LogMonitorTests/UtilityTests.cpp
@@ -1,0 +1,56 @@
+//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+
+#include "pch.h"
+
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+#define BUFFER_SIZE 65536
+
+namespace UtilityTests
+{
+    ///
+    /// Tests of Utility class methods.
+    ///
+    TEST_CLASS(UtilityTests)
+    {
+    public:
+        TEST_METHOD(TestisJsonNumberTrue)
+        {
+            PWSTR str = L"-0.12";
+            Assert::IsTrue(Utility::isJsonNumber(str), L"should return true -0.12");
+
+            str = L"-1.1234";
+            Assert::IsTrue(Utility::isJsonNumber(str), L"should return true for -1.1234");
+
+            str = L"1.12";
+            Assert::IsTrue(Utility::isJsonNumber(str), L"should return true for 1.12");
+
+            str = L"1";
+            Assert::IsTrue(Utility::isJsonNumber(str), L"should return true for 1");
+
+            str = L"0";
+            Assert::IsTrue(Utility::isJsonNumber(str), L"should return true for 0");
+
+            str = L"456662";
+            Assert::IsTrue(Utility::isJsonNumber(str), L"should return true for 456662");
+
+            str = L"456662.8989";
+            Assert::IsTrue(Utility::isJsonNumber(str), L"should return true for 456662.8989");
+        }
+        TEST_METHOD(TestisJsonNumberFalse)
+        {
+            PWSTR str = L"false";
+            Assert::IsFalse(Utility::isJsonNumber(str), L"should return false for \"false\"");
+
+            str = L"12.12.89.12";
+            Assert::IsFalse(Utility::isJsonNumber(str), L"should return calse for 12.12.89.12");
+
+            str = L"1200.23x";
+            Assert::IsFalse(Utility::isJsonNumber(str), L"should return false for 1200.23x");
+        }
+    };
+}

--- a/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
+++ b/LogMonitor/src/LogMonitor/ConfigFileParser.cpp
@@ -316,7 +316,6 @@ ReadSourceAttributes(
             // * eventFormatMultiLine
             // * startAtOldestRecord
             // * includeSubdirectories
-            // * includeFileNames
             //
             else if (
                 _wcsnicmp(
@@ -331,10 +330,7 @@ ReadSourceAttributes(
                     key.c_str(),
                     JSON_TAG_INCLUDE_SUBDIRECTORIES,
                     _countof(JSON_TAG_INCLUDE_SUBDIRECTORIES)) == 0
-                || _wcsnicmp(
-                    key.c_str(),
-                    JSON_TAG_INCLUDE_FILENAMES,
-                    _countof(JSON_TAG_INCLUDE_FILENAMES)) == 0)
+            )
             {
                 Attributes[key] = new bool{ Parser.ParseBooleanValue() };
             }
@@ -660,7 +656,6 @@ void _PrintSettings(_Out_ LoggerSettings& Config)
             std::wprintf(L"\t\tDirectory: %ls\n", sourceFile->Directory.c_str());
             std::wprintf(L"\t\tFilter: %ls\n", sourceFile->Filter.c_str());
             std::wprintf(L"\t\tIncludeSubdirectories: %ls\n", sourceFile->IncludeSubdirectories ? L"true" : L"false");
-            std::wprintf(L"\t\tIncludeFileNames: %ls\n", sourceFile->IncludeFileNames ? L"true" : L"false");
             std::wprintf(L"\n");
 
             break;

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -552,8 +552,11 @@ EventMonitor::PrintEvent(
 
             if (status == ERROR_SUCCESS)
             {
+                // supporting JSON fmt by default
+                auto logFmt = L"{\"Source\": \"EventLog\",\"LogEntry\": {\"Time\": \"%s\",\"Channel\": \"%s\",\"Level\": \"%s\",\"EventId\": %u,\"Message\": \"%s\"}}";;
+
                 std::wstring formattedEvent = Utility::FormatString(
-                    L"<Source>EventLog</Source><Time>%s</Time><LogEntry><Channel>%s</Channel><Level>%s</Level><EventId>%u</EventId><Message>%s</Message></LogEntry>",
+                    logFmt,
                     Utility::FileTimeToString(fileTimeCreated).c_str(),
                     channelName.c_str(),
                     c_LevelToString[static_cast<UINT8>(level)].c_str(),

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1683,13 +1683,28 @@ LogFileMonitor::ReadLogFile(
 }
 
 void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstring FileName) {
-    wstring prefix;
-    if (m_includeFileNames)
-    {
-        prefix = Utility::FormatString(L"[Log File: %s] ", FileName.c_str());
-    }
+    auto logFmt = L"{\"Source\":\"File\",\"LogEntry\":{\"Logline\":\"%s\",\"FileName\":\"%s\"},\"SchemaVersion\":\"1.0.0\"}";
 
-    logWriter.WriteConsoleLog(prefix + Utility::ReplaceAll(Message, L"\n", L"\n" + prefix));
+    while (true) {
+        size_t start = 0;
+        size_t i = 0;
+
+        i = Message.find(L"\n", start);
+        if (i == std::string::npos) {
+            break;
+        }
+
+        // substr except ith (\n)
+        auto msg = Message.substr(start, i - start);
+        start = i + 1;
+        // remove \r if any, usually before \n
+        if (msg.substr(msg.size() - 1) == L"\r") {
+            msg.replace(msg.size() - 1, 1, L"");
+        }
+        auto log = Utility::FormatString(logFmt, msg.c_str(), FileName.c_str());
+
+        logWriter.WriteConsoleLog(log);
+    }
 }
 
 DWORD

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -39,13 +39,11 @@ using namespace std;
 ///
 LogFileMonitor::LogFileMonitor(_In_ const std::wstring& LogDirectory,
                                _In_ const std::wstring& Filter,
-                               _In_ bool IncludeSubfolders,
-                               _In_ bool IncludeFileNames
+                               _In_ bool IncludeSubfolders
                                ) :
                                m_logDirectory(LogDirectory),
                                m_filter(Filter),
-                               m_includeSubfolders(IncludeSubfolders),
-                               m_includeFileNames(IncludeFileNames)
+                               m_includeSubfolders(IncludeSubfolders)
 {
     m_stopEvent = NULL;
     m_overlappedEvent = NULL;
@@ -1464,15 +1462,6 @@ LogFileMonitor::ReadLogFile(
         }
     }
 
-    //
-    //log the name of the source log file if includeFileNames field if true
-    //
-    wstring fileName;
-    if (m_includeFileNames)
-    {
-        fileName = Utility::FormatString(L"[Log File: %ws] ", LogFileInfo->FileName.c_str()).c_str();
-    }
-
     const DWORD bytesToRead = 4096;
     std::vector<BYTE> logFileContents(
         static_cast<size_t>(bytesToRead));
@@ -1691,6 +1680,9 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
 
         i = Message.find(L"\n", start);
         if (i == std::string::npos) {
+            // only one-line log
+            auto log = Utility::FormatString(logFmt, Message.c_str(), FileName.c_str());
+            logWriter.WriteConsoleLog(log);
             break;
         }
 
@@ -1702,7 +1694,6 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
             msg.replace(msg.size() - 1, 1, L"");
         }
         auto log = Utility::FormatString(logFmt, msg.c_str(), FileName.c_str());
-
         logWriter.WriteConsoleLog(log);
     }
 }

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1694,7 +1694,9 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
         }
         // ignore empty lines
         if (msg.size() > 0) {
-            auto log = Utility::FormatString(logFmt, msg.c_str(), FileName.c_str());
+            // escape backslashes in FileName
+            auto fmtFileName = Utility::ReplaceAll(FileName, L"\\", L"\\\\");
+            auto log = Utility::FormatString(logFmt, msg.c_str(), fmtFileName.c_str());
             logWriter.WriteConsoleLog(log);
         }
 

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.h
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.h
@@ -60,8 +60,7 @@ public:
     LogFileMonitor(
         _In_ const std::wstring& LogDirectory,
         _In_ const std::wstring& Filter,
-        _In_ bool IncludeSubfolders,
-        _In_ bool IncludeFileNames
+        _In_ bool IncludeSubfolders
         );
 
     ~LogFileMonitor();
@@ -74,7 +73,6 @@ private:
     std::wstring m_shortLogDirectory;
     std::wstring m_filter;
     bool m_includeSubfolders;
-    bool m_includeFileNames;
 
     //
     // Signaled by destructor to request the spawned thread to stop.

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -29,13 +29,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -48,7 +48,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -42,7 +42,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -156,6 +156,7 @@
     <ClInclude Include="EtwMonitor.h" />
     <ClInclude Include="EventMonitor.h" />
     <ClInclude Include="FileMonitor\*.h" />
+    <ClInclude Include="LogFileMonitor.h" />
     <ClInclude Include="LogWriter.h" />
     <ClInclude Include="Parser\ConfigFileParser.h" />
     <ClInclude Include="Parser\JsonFileParser.h" />

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj.filters
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj.filters
@@ -18,37 +18,40 @@
     <ClInclude Include="pch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="EtwMonitor.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="EventMonitor.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="LogWriter.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ProcessMonitor.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Utility.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Parser\ConfigFileParser.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Parser\LoggerSettings.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="version.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Parser\JsonFileParser.h">
-      <Filter>Source Files</Filter>
-    </ClInclude>
     <ClInclude Include="FileMonitor\*.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LogFileMonitor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EtwMonitor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="EventMonitor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Parser\ConfigFileParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Parser\JsonFileParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Parser\LoggerSettings.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LogWriter.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ProcessMonitor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Utility.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/LogMonitor/src/LogMonitor/Main.cpp
+++ b/LogMonitor/src/LogMonitor/Main.cpp
@@ -113,8 +113,7 @@ void StartMonitors(_In_ LoggerSettings& settings)
                     std::shared_ptr<LogFileMonitor> logfileMon = make_shared<LogFileMonitor>(
                         sourceFile->Directory,
                         sourceFile->Filter,
-                        sourceFile->IncludeSubdirectories,
-                        sourceFile->IncludeFileNames
+                        sourceFile->IncludeSubdirectories
                     );
                     g_logfileMonitors.push_back(std::move(logfileMon));
                 }

--- a/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
+++ b/LogMonitor/src/LogMonitor/Parser/LoggerSettings.h
@@ -20,7 +20,6 @@
 #define JSON_TAG_DIRECTORY L"directory"
 #define JSON_TAG_FILTER L"filter"
 #define JSON_TAG_INCLUDE_SUBDIRECTORIES L"includeSubdirectories"
-#define JSON_TAG_INCLUDE_FILENAMES L"includeFileNames"
 #define JSON_TAG_PROVIDERS L"providers"
 
 ///
@@ -255,7 +254,6 @@ public:
     std::wstring Directory;
     std::wstring Filter;
     bool IncludeSubdirectories = false;
-    bool IncludeFileNames = false;
 
     static bool Unwrap(
         _In_ AttributesMap& Attributes,
@@ -293,15 +291,6 @@ public:
             && Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES] != nullptr)
         {
             NewSource.IncludeSubdirectories = *(bool*)Attributes[JSON_TAG_INCLUDE_SUBDIRECTORIES];
-        }
-
-        //
-        // includeFileNames is an optional value
-        //
-        if (Attributes.find(JSON_TAG_INCLUDE_FILENAMES) != Attributes.end()
-            && Attributes[JSON_TAG_INCLUDE_FILENAMES] != nullptr)
-        {
-            NewSource.IncludeFileNames = *(bool*)Attributes[JSON_TAG_INCLUDE_FILENAMES];
         }
 
         return true;

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -4,6 +4,7 @@
 //
 
 #include "pch.h"
+#include <regex>
 
 using namespace std;
 
@@ -245,3 +246,13 @@ std::wstring Utility::ReplaceAll(_In_ std::wstring Str, _In_ const std::wstring&
     return Str;
 }
 
+
+/// 
+/// helper function for a basic check if a string is a Number (JSON)
+/// as per the JSON spec - https://www.json.org/json-en.html
+/// 
+bool Utility::isJsonNumber(_In_ PWSTR str)
+{
+    wregex isNumber(L"(^\\-?\\d+$)|(^\\-?\\d+\\.\\d+)$");
+    return regex_search(str, isNumber);
+}

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -44,4 +44,6 @@ public:
         _In_ const std::wstring& From,
         _In_ const std::wstring& To
     );
+
+    static bool isJsonNumber(_In_ PWSTR str);
 };

--- a/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json
+++ b/LogMonitor/src/LogMonitor/sample-config-files/IIS/LogMonitorConfig.json
@@ -20,8 +20,7 @@
         "type": "File",
         "directory": "c:\\inetpub\\logs",
         "filter": "*.log",
-        "includeSubdirectories": true,
-        "includeFileNames": false
+        "includeSubdirectories": true
       },
       {
         "type": "ETW",


### PR DESCRIPTION
Escape sequences that may break the whole JSON format or the validity of the string e.g.
![image](https://user-images.githubusercontent.com/261265/211825882-c41c8eb9-b6b1-4222-84c9-2675f429f4cf.png)

vs:

![image](https://user-images.githubusercontent.com/261265/211825961-e85619a1-8202-44cf-b7f2-aab606df6b3c.png)
