### PR TITLE
feat: sanitize json string

### DIFF
--- a/LogMonitor/LogMonitorTests/UtilityTests.cpp
+++ b/LogMonitor/LogMonitorTests/UtilityTests.cpp
@@ -41,6 +41,7 @@ namespace UtilityTests
             str = L"456662.8989";
             Assert::IsTrue(Utility::isJsonNumber(str), L"should return true for 456662.8989");
         }
+
         TEST_METHOD(TestisJsonNumberFalse)
         {
             PWSTR str = L"false";
@@ -51,6 +52,30 @@ namespace UtilityTests
 
             str = L"1200.23x";
             Assert::IsFalse(Utility::isJsonNumber(str), L"should return false for 1200.23x");
+        }
+
+        TEST_METHOD(TestSanitizeJson)
+        {
+            std::wstring str = L"say, \"hello\"";
+            std::wstring expect = L"say, \\\"hello\\\"";
+            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \"");
+            str = L"\"hello\"";
+            expect = L"\\\"hello\\\"";
+            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \"");
+
+            str = L"hello\r\nworld";
+            expect = L"hello\\r\\nworld";
+            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \r and \n");
+            str = L"\r\nHello\r\n";
+            expect = L"\\r\\nHello\\r\\n";
+            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \r and \n");
+
+            str = L"\\Driver\\XX\\";
+            expect = L"\\\\Driver\\\\XX\\\\";
+            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \\");
+            str = L"C:\\Drive\\XX";
+            expect = L"C:\\\\Drive\\\\XX";
+            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \\");
         }
     };
 }

--- a/LogMonitor/LogMonitorTests/UtilityTests.cpp
+++ b/LogMonitor/LogMonitorTests/UtilityTests.cpp
@@ -58,24 +58,30 @@ namespace UtilityTests
         {
             std::wstring str = L"say, \"hello\"";
             std::wstring expect = L"say, \\\"hello\\\"";
-            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \"");
+            Utility::SanitizeJson(str);
+            Assert::IsTrue(str == expect, L"should escape \"");
             str = L"\"hello\"";
             expect = L"\\\"hello\\\"";
-            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \"");
+            Utility::SanitizeJson(str);
+            Assert::IsTrue(str == expect, L"should escape \"");
 
             str = L"hello\r\nworld";
             expect = L"hello\\r\\nworld";
-            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \r and \n");
+            Utility::SanitizeJson(str);
+            Assert::IsTrue(str == expect, L"should escape \r and \n");
             str = L"\r\nHello\r\n";
             expect = L"\\r\\nHello\\r\\n";
-            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \r and \n");
+            Utility::SanitizeJson(str);
+            Assert::IsTrue(str == expect, L"should escape \r and \n");
 
             str = L"\\Driver\\XX\\";
             expect = L"\\\\Driver\\\\XX\\\\";
-            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \\");
+            Utility::SanitizeJson(str);
+            Assert::IsTrue(str == expect, L"should escape \\");
             str = L"C:\\Drive\\XX";
             expect = L"C:\\\\Drive\\\\XX";
-            Assert::IsTrue(Utility::SanitizeJson(str) == expect, L"should escape \\");
+            Utility::SanitizeJson(str);
+            Assert::IsTrue(str == expect, L"should escape \\");
         }
     };
 }

--- a/LogMonitor/src/LogMonitor/EtwMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EtwMonitor.cpp
@@ -1120,12 +1120,16 @@ EtwMonitor::_FormatData(
             if (ERROR_SUCCESS == status)
             {
                 auto fd = (PWCHAR)formattedData.data();
-                auto sep = L"";
                 if (!Utility::isJsonNumber(fd)) {
-                    // enclose fd within double quotes.
-                    sep = L"\"";
+                    // clean the JSON string `fd`
+                    wstring fdStr(fd);
+                    Utility::SanitizeJson(fdStr);
+                    Result << L"\"" << fdStr << L"\"";
                 }
-                Result << sep << fd << sep;
+                else {
+                    Result << fd;
+                }
+                
 
                 UserData += userDataConsumed;
             }

--- a/LogMonitor/src/LogMonitor/EventMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/EventMonitor.cpp
@@ -555,30 +555,17 @@ EventMonitor::PrintEvent(
                 // supporting JSON fmt by default
                 auto logFmt = L"{\"Source\": \"EventLog\",\"LogEntry\": {\"Time\": \"%s\",\"Channel\": \"%s\",\"Level\": \"%s\",\"EventId\": %u,\"Message\": \"%s\"}}";;
 
+                // sanitize message
+                std::wstring msg(m_eventMessageBuffer.begin(), m_eventMessageBuffer.end());
+                Utility::SanitizeJson(msg);
+
                 std::wstring formattedEvent = Utility::FormatString(
                     logFmt,
                     Utility::FileTimeToString(fileTimeCreated).c_str(),
                     channelName.c_str(),
                     c_LevelToString[static_cast<UINT8>(level)].c_str(),
                     eventId,
-                    (LPWSTR)(&m_eventMessageBuffer[0])
-                );
-
-                //
-                // If the multi-line option is disabled, remove all new lines from the output.
-                //
-                if (!this->m_eventFormatMultiLine)
-                {
-                    std::transform(formattedEvent.begin(), formattedEvent.end(), formattedEvent.begin(),
-                        [](WCHAR ch) {
-                            switch (ch) {
-                            case L'\r':
-                            case L'\n':
-                                return L' ';
-                            }
-                            return ch;
-                        });
-                }
+                    msg.c_str());
 
                 logWriter.WriteConsoleLog(formattedEvent);
             }

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1696,6 +1696,8 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
         if (msg.size() > 0) {
             // escape backslashes in FileName
             auto fmtFileName = Utility::ReplaceAll(FileName, L"\\", L"\\\\");
+            // sanitize msg
+            //std::wstring msg2 = Utility::JsonSanitize(msg);
             auto log = Utility::FormatString(logFmt, msg.c_str(), fmtFileName.c_str());
             logWriter.WriteConsoleLog(log);
         }

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1697,8 +1697,8 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
             // escape backslashes in FileName
             auto fmtFileName = Utility::ReplaceAll(FileName, L"\\", L"\\\\");
             // sanitize msg
-            //std::wstring msg2 = Utility::JsonSanitize(msg);
-            auto log = Utility::FormatString(logFmt, msg.c_str(), fmtFileName.c_str());
+            std::wstring msg2 = Utility::SanitizeJson(msg);
+            auto log = Utility::FormatString(logFmt, msg2.c_str(), fmtFileName.c_str());
             logWriter.WriteConsoleLog(log);
         }
 

--- a/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/LogFileMonitor.cpp
@@ -1697,8 +1697,8 @@ void LogFileMonitor::WriteToConsole( _In_ std::wstring Message, _In_ std::wstrin
             // escape backslashes in FileName
             auto fmtFileName = Utility::ReplaceAll(FileName, L"\\", L"\\\\");
             // sanitize msg
-            std::wstring msg2 = Utility::SanitizeJson(msg);
-            auto log = Utility::FormatString(logFmt, msg2.c_str(), fmtFileName.c_str());
+            Utility::SanitizeJson(msg);
+            auto log = Utility::FormatString(logFmt, msg.c_str(), fmtFileName.c_str());
             logWriter.WriteConsoleLog(log);
         }
 

--- a/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
+++ b/LogMonitor/src/LogMonitor/LogMonitor.vcxproj
@@ -107,11 +107,15 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <BrowseInformation>true</BrowseInformation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Bscmake>
+      <PreserveSbr>true</PreserveSbr>
+    </Bscmake>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -259,26 +259,28 @@ bool Utility::isJsonNumber(_In_ PWSTR str)
 
 ///
 /// helper function to "sanitize" a string to be valid JSON
-/// i.e. escale \", \n and \\ within a string
+/// i.e. escape ", \r, \n and \ within a string
+/// to \", \\r, \\n and \\ respectively
 ///
-static std::wstring JsonSanitize(_In_ std::wstring str)
+std::wstring Utility::SanitizeJson(_In_ std::wstring str)
 {
+    std::wstring cleanStr(str);
     size_t i = 0;
-    while (i < str.size()) {
-        auto sub = str.substr(i, 1);
+    while (i < cleanStr.size()) {
+        auto sub = cleanStr.substr(i, 1);
         if (sub == L"\"") {
-            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
+            if ((i > 0 && cleanStr.substr(i - 1, 1) != L"\\")
                 || i == 0)
             {
-                str.replace(i, 1, L"\\\"");
+                cleanStr.replace(i, 1, L"\\\"");
                 i++;
             }
         }
         else if (sub == L"\\") {
-            if ((i < str.size() - 1 && str.substr(i + 1, 1) != L"\\")
-                || i == str.size() - 1)
+            if ((i < cleanStr.size() - 1 && cleanStr.substr(i + 1, 1) != L"\\")
+                || i == cleanStr.size() - 1)
             {
-                str.replace(i, 1, L"\\\\");
+                cleanStr.replace(i, 1, L"\\\\");
                 i++;
             }
             else {
@@ -286,23 +288,23 @@ static std::wstring JsonSanitize(_In_ std::wstring str)
             }
         }
         else if (sub == L"\n") {
-            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
+            if ((i > 0 && cleanStr.substr(i - 1, 1) != L"\\")
                 || i == 0)
             {
-                str.replace(i, 1, L"\\n");
+                cleanStr.replace(i, 1, L"\\n");
                 i++;
             }
         }
         else if (sub == L"\r") {
-            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
+            if ((i > 0 && cleanStr.substr(i - 1, 1) != L"\\")
                 || i == 0)
             {
-                str.replace(i, 1, L"\\r");
+                cleanStr.replace(i, 1, L"\\r");
                 i++;
             }
         }
         i++;
     }
 
-    return str;
+    return cleanStr;
 }

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -256,3 +256,53 @@ bool Utility::isJsonNumber(_In_ PWSTR str)
     wregex isNumber(L"(^\\-?\\d+$)|(^\\-?\\d+\\.\\d+)$");
     return regex_search(str, isNumber);
 }
+
+///
+/// helper function to "sanitize" a string to be valid JSON
+/// i.e. escale \", \n and \\ within a string
+///
+static std::wstring JsonSanitize(_In_ std::wstring str)
+{
+    size_t i = 0;
+    while (i < str.size()) {
+        auto sub = str.substr(i, 1);
+        if (sub == L"\"") {
+            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
+                || i == 0)
+            {
+                str.replace(i, 1, L"\\\"");
+                i++;
+            }
+        }
+        else if (sub == L"\\") {
+            if ((i < str.size() - 1 && str.substr(i + 1, 1) != L"\\")
+                || i == str.size() - 1)
+            {
+                str.replace(i, 1, L"\\\\");
+                i++;
+            }
+            else {
+                i += 2;
+            }
+        }
+        else if (sub == L"\n") {
+            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
+                || i == 0)
+            {
+                str.replace(i, 1, L"\\n");
+                i++;
+            }
+        }
+        else if (sub == L"\r") {
+            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
+                || i == 0)
+            {
+                str.replace(i, 1, L"\\r");
+                i++;
+            }
+        }
+        i++;
+    }
+
+    return str;
+}

--- a/LogMonitor/src/LogMonitor/Utility.cpp
+++ b/LogMonitor/src/LogMonitor/Utility.cpp
@@ -262,25 +262,24 @@ bool Utility::isJsonNumber(_In_ PWSTR str)
 /// i.e. escape ", \r, \n and \ within a string
 /// to \", \\r, \\n and \\ respectively
 ///
-std::wstring Utility::SanitizeJson(_In_ std::wstring str)
+void Utility::SanitizeJson(_Inout_ std::wstring& str)
 {
-    std::wstring cleanStr(str);
     size_t i = 0;
-    while (i < cleanStr.size()) {
-        auto sub = cleanStr.substr(i, 1);
+    while (i < str.size()) {
+        auto sub = str.substr(i, 1);
         if (sub == L"\"") {
-            if ((i > 0 && cleanStr.substr(i - 1, 1) != L"\\")
+            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
                 || i == 0)
             {
-                cleanStr.replace(i, 1, L"\\\"");
+                str.replace(i, 1, L"\\\"");
                 i++;
             }
         }
         else if (sub == L"\\") {
-            if ((i < cleanStr.size() - 1 && cleanStr.substr(i + 1, 1) != L"\\")
-                || i == cleanStr.size() - 1)
+            if ((i < str.size() - 1 && str.substr(i + 1, 1) != L"\\")
+                || i == str.size() - 1)
             {
-                cleanStr.replace(i, 1, L"\\\\");
+                str.replace(i, 1, L"\\\\");
                 i++;
             }
             else {
@@ -288,23 +287,21 @@ std::wstring Utility::SanitizeJson(_In_ std::wstring str)
             }
         }
         else if (sub == L"\n") {
-            if ((i > 0 && cleanStr.substr(i - 1, 1) != L"\\")
+            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
                 || i == 0)
             {
-                cleanStr.replace(i, 1, L"\\n");
+                str.replace(i, 1, L"\\n");
                 i++;
             }
         }
         else if (sub == L"\r") {
-            if ((i > 0 && cleanStr.substr(i - 1, 1) != L"\\")
+            if ((i > 0 && str.substr(i - 1, 1) != L"\\")
                 || i == 0)
             {
-                cleanStr.replace(i, 1, L"\\r");
+                str.replace(i, 1, L"\\r");
                 i++;
             }
         }
         i++;
     }
-
-    return cleanStr;
 }

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -47,5 +47,5 @@ public:
 
     static bool isJsonNumber(_In_ PWSTR str);
 
-    static std::wstring SanitizeJson(_In_ std::wstring str);
+    static void SanitizeJson(_Inout_ std::wstring& str);
 };

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -47,5 +47,5 @@ public:
 
     static bool isJsonNumber(_In_ PWSTR str);
 
-    static std::wstring JsonSanitize(_In_ std::wstring str);
+    static std::wstring SanitizeJson(_In_ std::wstring str);
 };

--- a/LogMonitor/src/LogMonitor/Utility.h
+++ b/LogMonitor/src/LogMonitor/Utility.h
@@ -46,4 +46,6 @@ public:
     );
 
     static bool isJsonNumber(_In_ PWSTR str);
+
+    static std::wstring JsonSanitize(_In_ std::wstring str);
 };


### PR DESCRIPTION
Escape sequences that may break the whole JSON format or the validity of the string e.g.
![image](https://user-images.githubusercontent.com/261265/211825882-c41c8eb9-b6b1-4222-84c9-2675f429f4cf.png)

vs:

![image](https://user-images.githubusercontent.com/261265/211825961-e85619a1-8202-44cf-b7f2-aab606df6b3c.png)
